### PR TITLE
fix: exclude body from GET/HEAD requests in tokenExfiltrationDefense for Firefox compatibility

### DIFF
--- a/src/core/tokenExfiltrationDefense.ts
+++ b/src/core/tokenExfiltrationDefense.ts
@@ -243,10 +243,13 @@ function patchFetchApiToSubstituteTokenPlaceholder(params: {
                 );
             }
 
+            const method = request.method.toUpperCase();
+
             const nextInit: RequestInit = {
                 method: request.method,
                 headers,
-                body,
+                // NOTE: Firefox strictly enforces HTTP spec - GET/HEAD requests cannot have a body
+                ...(method !== "GET" && method !== "HEAD" && body !== undefined ? { body } : {}),
                 mode: request.mode,
                 credentials: request.credentials,
                 cache: request.cache,


### PR DESCRIPTION
## Problem

  When `enableTokenExfiltrationDefense` is enabled, all fetch requests fail on Firefox with:

  TypeError: Window.fetch: HEAD or GET Request cannot have a body.

  Chrome works fine because it silently ignores the body on GET/HEAD requests, but Firefox strictly enforces the HTTP specification (RFC 7231).

  ## Root Cause

  In `patchFetchApiToSubstituteTokenPlaceholder`, the `nextInit` object unconditionally includes the `body` property, even for GET/HEAD requests where it should be omitted.

  ## Solution

  Conditionally include `body` only for methods that support request bodies (not GET/HEAD). This follows the same pattern already used in `dpop.ts` (line 346-348).

  ## Testing

  - Tested on Firefox 133 - requests now succeed
  - Chrome behavior unchanged
  - The fix mirrors existing code patterns in the codebase (`src/core/dpop.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected HTTP request handling to prevent body transmission with GET and HEAD methods, ensuring compliance with HTTP standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->