### PR TITLE
Only prevent monkey patching of function's call() behavior. Actually …

### DIFF
--- a/src/core/earlyInit_DPoP.ts
+++ b/src/core/earlyInit_DPoP.ts
@@ -569,10 +569,10 @@ export function implementFetchAndXhrDPoPInterceptor() {
                 handledRequestState: undefined
             });
 
-            return XMLHttpRequest_prototype_actual.open.apply(
+            return XMLHttpRequest_prototype_actual.open.call(
                 this,
                 // @ts-expect-error
-                arguments
+                ...arguments
             );
         };
 
@@ -635,10 +635,10 @@ export function implementFetchAndXhrDPoPInterceptor() {
                 return;
             }
 
-            return XMLHttpRequest_prototype_actual.setRequestHeader.apply(
+            return XMLHttpRequest_prototype_actual.setRequestHeader.call(
                 this,
                 // @ts-expect-error
-                arguments
+                ...arguments
             );
         };
 
@@ -725,21 +725,13 @@ export function implementFetchAndXhrDPoPInterceptor() {
                     );
                     XMLHttpRequest_prototype_actual.setRequestHeader.call(this, "DPoP", dpopProof);
 
-                    XMLHttpRequest_prototype_actual.send.apply(
-                        this,
-                        // @ts-expect-error
-                        arguments
-                    );
+                    XMLHttpRequest_prototype_actual.send.call(this, ...arguments);
                 });
 
                 return;
             }
 
-            return XMLHttpRequest_prototype_actual.send.apply(
-                this,
-                // @ts-expect-error
-                arguments
-            );
+            return XMLHttpRequest_prototype_actual.send.call(this, ...arguments);
         };
     }
 }


### PR DESCRIPTION
…prevent it on all functions, not just on Function.prototype.call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal function-call forwarding and XMLHttpRequest interaction handling.
  * Revised browser runtime freezing/patching behavior to target a more specific call pathway and tighten interception mechanics.

**Note:** No user-facing changes; functional behavior for end users remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->