### PR TITLE
fix: remove unused error handling code in createIframeTimeoutInitiali…

### DIFF
--- a/src/core/diagnostic.ts
+++ b/src/core/diagnostic.ts
@@ -127,8 +127,6 @@ export async function createIframeTimeoutInitializationError(params: {
                 isAuthServerLikelyDown: false,
                 messageOrCause: new Error(
                     `Unexpected error while trying to diagnose why the silent sign-in process timed out.`,
-                    // @ts-expect-error
-                    { cause: cspOrError }
                 )
             });
         }


### PR DESCRIPTION
…zationError function

Issue appear in my sentry issue.

**cspOrError is not defined**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app’s initialization error handling when a required redirect setting cannot be retrieved, so failures are reported more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->