### PR TITLE
feat: opt-in shared scope for micro-frontend setups

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,5 @@
 import * as child_process from "child_process";
+import * as esbuild from "esbuild";
 import * as fs from "fs";
 import {
     join as pathJoin,
@@ -214,25 +215,22 @@ for (const targetFormat of ["cjs", "esm"] as const) {
                             }
 
                             const bundledFilePath = pathJoin(cacheDirPath, "bundle.js");
-                            const esbuildExternalNodeBuiltins =
-                                targetRuntime === "frontend"
-                                    ? ["--external:crypto", "--external:buffer", "--external:util"]
-                                    : [];
 
-                            run(
-                                [
-                                    `npx esbuild`,
-                                    `'${filePath}'`,
-                                    "--bundle",
-                                    "--format=esm",
-                                    "--platform=browser",
-                                    "--main-fields=browser,module,main",
-                                    "--conditions=browser",
-                                    // Do not pull node polyfills for vendor bundles that only run in browsers.
-                                    ...esbuildExternalNodeBuiltins,
-                                    `--outfile='${bundledFilePath}'`
-                                ].join(" ")
-                            );
+                            // The JS api instead of the cli: no shell, so paths need no quoting.
+                            esbuild.buildSync({
+                                entryPoints: [filePath],
+                                bundle: true,
+                                format: "esm",
+                                platform: "browser",
+                                mainFields: ["browser", "module", "main"],
+                                conditions: ["browser"],
+                                // Do not pull node polyfills for vendor bundles that only run in browsers.
+                                external:
+                                    targetRuntime === "frontend"
+                                        ? ["crypto", "buffer", "util"]
+                                        : [],
+                                outfile: bundledFilePath
+                            });
 
                             fs.copyFileSync(bundledFilePath, filePath);
 
@@ -256,10 +254,12 @@ for (const targetFormat of ["cjs", "esm"] as const) {
                                         ``,
                                         `module.exports = {`,
                                         `   mode: 'production',`,
-                                        `  entry: '${filePath}',`,
+                                        // JSON.stringify so that the backslashes of a Windows path
+                                        // aren't read as escape sequences.
+                                        `  entry: ${JSON.stringify(filePath)},`,
                                         `  output: {`,
-                                        `    path: '${webpackOutputDirPath}',`,
-                                        `    filename: '${pathBasename(webpackOutputFilePath)}',`,
+                                        `    path: ${JSON.stringify(webpackOutputDirPath)},`,
+                                        `    filename: ${JSON.stringify(pathBasename(webpackOutputFilePath))},`,
                                         `    libraryTarget: 'commonjs2',`,
                                         `    chunkFormat: 'module'`,
                                         `  },`,

--- a/src/core/createOidc.ts
+++ b/src/core/createOidc.ts
@@ -28,6 +28,7 @@ import { authResponseToUrl, type AuthResponse } from "./AuthResponse";
 import { getPersistedAuthState, persistAuthState } from "./persistedAuthState";
 import type { Oidc } from "./Oidc";
 import { createEvt } from "../tools/Evt";
+import { getSharedState } from "./sharedScope";
 import { getHaveSharedParentDomain } from "../tools/haveSharedParentDomain";
 import {
     createLoginOrGoToAuthServer,
@@ -266,13 +267,17 @@ export type ParamsOfCreateOidc<
     disableDPoP?: true;
 };
 
-const globalContext = {
+const globalContext_moduleScoped = {
     prOidcByConfigId: new Map<string, Promise<Oidc<any>>>(),
     hasLogoutBeenCalled: id<boolean>(false),
     dExports_earlyInit: new Deferred<Exports_earlyInit>(),
     dExports_tokenSubstitution: new Deferred<Exports_tokenSubstitution>(),
     dExports_DPoP: new Deferred<Exports_DPoP>()
 };
+
+// Shared across bundles in micro-frontend setups, resolved at use time because this module is
+// dynamically imported and may evaluate before oidcEarlyInit enables the shared scope.
+const getGlobalContext = () => getSharedState("globalContext", globalContext_moduleScoped);
 
 export type Exports_earlyInit =
     | { shouldLoadApp: false }
@@ -288,7 +293,7 @@ export type Exports_earlyInit =
       };
 
 export function registerExports_earlyInit(exports: Exports_earlyInit): void {
-    globalContext.dExports_earlyInit.resolve(exports);
+    getGlobalContext().dExports_earlyInit.resolve(exports);
 }
 
 export type Exports_tokenSubstitution = {
@@ -307,7 +312,7 @@ export namespace Exports_tokenSubstitution {
 }
 
 export function registerExports_tokenSubstitution(exports: Exports_tokenSubstitution): void {
-    globalContext.dExports_tokenSubstitution.resolve(exports);
+    getGlobalContext().dExports_tokenSubstitution.resolve(exports);
 }
 
 export type Exports_DPoP = {
@@ -339,7 +344,7 @@ export namespace Exports_DPoP {
 }
 
 export function registerExports_DPoP(exports: Exports_DPoP): void {
-    globalContext.dExports_DPoP.resolve(exports);
+    getGlobalContext().dExports_DPoP.resolve(exports);
 }
 
 /** @see: https://docs.oidc-spa.dev/v/v10/usage */
@@ -384,7 +389,7 @@ export async function createOidc<
 
     const configId = getConfigId({ issuerUri, clientId });
 
-    const { prOidcByConfigId } = globalContext;
+    const { prOidcByConfigId } = getGlobalContext();
 
     use_previous_instance: {
         const prOidc = prOidcByConfigId.get(configId);
@@ -464,7 +469,7 @@ export async function createOidc_nonMemoized<
             );
         }, 3_000);
 
-        const exports_earlyInit = await globalContext.dExports_earlyInit.pr;
+        const exports_earlyInit = await getGlobalContext().dExports_earlyInit.pr;
 
         window.clearTimeout(timer);
 
@@ -484,9 +489,9 @@ export async function createOidc_nonMemoized<
     const sessionRestorationMethod =
         sessionRestorationMethod_params ?? sessionRestorationMethod_earlyInit ?? "auto";
 
-    const { value: exports_tokenSubstitution } = globalContext.dExports_tokenSubstitution.getState();
+    const { value: exports_tokenSubstitution } = getGlobalContext().dExports_tokenSubstitution.getState();
 
-    const { value: exports_DPoP } = globalContext.dExports_DPoP.getState();
+    const { value: exports_DPoP } = getGlobalContext().dExports_DPoP.getState();
 
     const scopes = Array.from(new Set(["openid", ...(params.scopes ?? ["profile"])]));
 
@@ -1567,12 +1572,12 @@ export async function createOidc_nonMemoized<
         },
         getDecodedIdToken: () => currentTokens.decodedIdToken,
         logout: async params => {
-            if (globalContext.hasLogoutBeenCalled) {
+            if (getGlobalContext().hasLogoutBeenCalled) {
                 log?.("logout() has already been called, ignoring the call");
                 return new Promise<never>(() => {});
             }
 
-            globalContext.hasLogoutBeenCalled = true;
+            getGlobalContext().hasLogoutBeenCalled = true;
 
             const rootRelativePostLogoutRedirectUrl: string = (() => {
                 switch (params.redirectTo) {

--- a/src/core/earlyInit.ts
+++ b/src/core/earlyInit.ts
@@ -7,6 +7,7 @@ import { createEvt, type Evt } from "../tools/Evt";
 import { setGetRootRelativeOriginalLocationHref_earlyInit } from "./earlyInit_rootRelativeOriginalLocationHref";
 import { prModuleCreateOidc } from "./earlyInit_prModuleCreateOidc";
 import { toFullyQualifiedUrl } from "../tools/toFullyQualifiedUrl";
+import { enableSharedScope, getSharedState } from "./sharedScope";
 
 const IFRAME_MESSAGE_PREFIX = "oidc-spa:cross-window-messaging:";
 
@@ -56,16 +57,35 @@ export type ParamsOfEarlyInit = {
         enableDPoP?: () => void;
         enableTokenSubstitution?: () => void;
     };
+
+    /**
+     * Micro-frontend setups only: each remote bundles its own oidc-spa, so the callback handling
+     * and iframe listener run once per bundle and conflict. With this enabled that state is held
+     * on `window` and shared. Every participating bundle must pass it, and it makes the oidc
+     * state reachable by any script on the page, so only use it with trusted remotes.
+     */
+    isMicroFrontendSetup?: boolean;
 };
 
-let shouldLoadApp: boolean | undefined = undefined;
+const memo_moduleScoped: { shouldLoadApp: boolean | undefined } = { shouldLoadApp: undefined };
+
+// Shared so the non memoized init runs once per document, not once per bundle.
+const getMemo = () => getSharedState("earlyInitMemo", memo_moduleScoped);
 
 export function oidcEarlyInit(params?: ParamsOfEarlyInit) {
-    if (shouldLoadApp !== undefined) {
-        return { shouldLoadApp };
+    if (params?.isMicroFrontendSetup) {
+        enableSharedScope();
     }
 
-    shouldLoadApp = oidcEarlyInit_nonMemoized(params).shouldLoadApp;
+    const memo = getMemo();
+
+    if (memo.shouldLoadApp !== undefined) {
+        return { shouldLoadApp: memo.shouldLoadApp };
+    }
+
+    const { shouldLoadApp } = oidcEarlyInit_nonMemoized(params);
+
+    memo.shouldLoadApp = shouldLoadApp;
 
     return { shouldLoadApp };
 }

--- a/src/core/earlyInit_BASE_URL.ts
+++ b/src/core/earlyInit_BASE_URL.ts
@@ -1,13 +1,19 @@
 import { assert } from "../tools/tsafe/assert";
+import { getSharedState } from "./sharedScope";
 
-let BASE_URL: string | undefined = undefined;
+const store_moduleScoped: { BASE_URL: string | undefined } = { BASE_URL: undefined };
+
+// Shared across bundles, only one of them runs the init that sets this.
+const getStore = () => getSharedState("BASE_URL_earlyInit", store_moduleScoped);
 
 export function getBASE_URL_earlyInit() {
-    return BASE_URL;
+    return getStore().BASE_URL;
 }
 
 export function setBASE_URL_earlyInit(params: { BASE_URL: string }) {
-    assert(BASE_URL === undefined, "228");
+    const store = getStore();
 
-    BASE_URL = params.BASE_URL;
+    assert(store.BASE_URL === undefined, "228");
+
+    store.BASE_URL = params.BASE_URL;
 }

--- a/src/core/earlyInit_rootRelativeOriginalLocationHref.ts
+++ b/src/core/earlyInit_rootRelativeOriginalLocationHref.ts
@@ -1,8 +1,16 @@
 import { assert } from "../tools/tsafe/assert";
+import { getSharedState } from "./sharedScope";
 
-let rootRelativeOriginalLocationHref: string | undefined = undefined;
+const store_moduleScoped: { rootRelativeOriginalLocationHref: string | undefined } = {
+    rootRelativeOriginalLocationHref: undefined
+};
+
+// Shared across bundles, only one of them runs the init that sets this.
+const getStore = () =>
+    getSharedState("rootRelativeOriginalLocationHref_earlyInit", store_moduleScoped);
 
 export function getRootRelativeOriginalLocationHref_earlyInit() {
+    const { rootRelativeOriginalLocationHref } = getStore();
     assert(rootRelativeOriginalLocationHref !== undefined, "033");
     return rootRelativeOriginalLocationHref;
 }
@@ -10,6 +18,8 @@ export function getRootRelativeOriginalLocationHref_earlyInit() {
 export function setGetRootRelativeOriginalLocationHref_earlyInit(params: {
     rootRelativeOriginalLocationHref: string;
 }) {
-    assert(rootRelativeOriginalLocationHref === undefined, "393");
-    rootRelativeOriginalLocationHref = params.rootRelativeOriginalLocationHref;
+    const store = getStore();
+
+    assert(store.rootRelativeOriginalLocationHref === undefined, "393");
+    store.rootRelativeOriginalLocationHref = params.rootRelativeOriginalLocationHref;
 }

--- a/src/core/sharedScope.ts
+++ b/src/core/sharedScope.ts
@@ -1,0 +1,88 @@
+const WINDOW_KEY = "__oidc_spa_shared__";
+
+// Bumped on incompatible changes, a bundle seeing another format falls back to module scope.
+const FORMAT_VERSION = 1;
+
+type SharedStore = {
+    formatVersion: number;
+    isEnabled: boolean;
+    state: Record<string, unknown>;
+};
+
+// Sharing requires this bundle's own opt in, so a bundle that never passed the flag keeps its
+// module scoped state even when another bundle on the page enabled the store.
+let isEnabledInThisBundle = false;
+
+// Reading never creates the store, only enableSharedScope does.
+function peekStore(): SharedStore | undefined {
+    if (typeof window === "undefined") {
+        return undefined;
+    }
+
+    const store = (window as any)[WINDOW_KEY] as SharedStore | undefined;
+
+    if (store !== undefined && store.formatVersion !== FORMAT_VERSION) {
+        console.warn(
+            [
+                "oidc-spa: Another bundle on this page shares oidc state with format",
+                `${store.formatVersion}, this bundle expects ${FORMAT_VERSION}.`,
+                "Falling back to module scoped state for this bundle,",
+                "align the oidc-spa versions across your micro-frontends."
+            ].join(" ")
+        );
+        return undefined;
+    }
+
+    return store;
+}
+
+/** Moves oidc-spa's global state to `window` so every bundle on the page shares it. */
+export function enableSharedScope(): void {
+    if (typeof window === "undefined") {
+        return;
+    }
+
+    const store = ((window as any)[WINDOW_KEY] ??= {
+        formatVersion: FORMAT_VERSION,
+        isEnabled: false,
+        state: {}
+    }) as SharedStore;
+
+    if (store.formatVersion !== FORMAT_VERSION) {
+        return;
+    }
+
+    isEnabledInThisBundle = true;
+
+    if (store.isEnabled) {
+        return;
+    }
+
+    store.isEnabled = true;
+
+    console.warn(
+        [
+            "oidc-spa: Shared scope enabled.",
+            "OIDC state is accessible to all scripts on this page.",
+            "Only use this in trusted micro-frontend environments."
+        ].join(" ")
+    );
+}
+
+export function getIsSharedScopeEnabled(): boolean {
+    return isEnabledInThisBundle && (peekStore()?.isEnabled ?? false);
+}
+
+/**
+ * Shared instance of `obj` when enabled (first bundle donates, the rest adopt), otherwise `obj`.
+ * Call at use time, a module scope capture races against oidcEarlyInit enabling the scope.
+ */
+export function getSharedState<T extends object>(key: string, obj: T): T {
+    const store = peekStore();
+
+    if (!isEnabledInThisBundle || store === undefined || !store.isEnabled) {
+        return obj;
+    }
+
+    return (store.state[key] ??= obj) as T;
+}


### PR DESCRIPTION
Closes #169

Opt-in fix for the multi-bundle problem discussed in #169: each micro-frontend remote bundles its own copy of oidc-spa, so the module scoped earlyInit state and instance cache exist once per bundle. The first bundle's message listener calls stopImmediatePropagation and swallows the other bundles' iframe auth responses, and the auth callback is consumed by whichever bundle initialises first.

- New `oidcEarlyInit({ isMicroFrontendSetup: true })`. When set, the earlyInit memo, the createOidc global context, and the BASE_URL / original-location stores live on `window` under `__oidc_spa_shared__`, so all bundles share one listener, one instance cache, and one auth callback. Every participating bundle passes the flag.
- Shared state is resolved at use time, not module scope, so it cannot race against the dynamic import of createOidc.
- Reads never create the window global, only opting in does. The store carries a format version, a bundle seeing a different version falls back to its own module scope and warns.
- Default behaviour is byte-for-byte unchanged, nothing is written to window unless the flag is passed, and a console warning states the security trade-off when it is.
- Also fixes two Windows build failures in scripts/build.ts: the generated webpack config embedded unescaped backslash paths, and esbuild was invoked with single quoted paths that cmd.exe does not strip.

Verified in our production setup from #169 (React 17 host, Angular remote, React 19 remote, each bundling oidc-spa): with the flag on all three bundles the listener conflict and callback collisions are gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional shared initialization support for micro-frontend deployments, allowing compatible bundles to reuse OIDC state and configuration.
  * Added controls for enabling and checking shared-scope behavior.
  * Shared initialization values, callbacks, and session state can now be reused across compatible bundles.

* **Bug Fixes**
  * Improved Windows build compatibility by correctly handling paths containing backslashes.
  * Added safe fallback behavior when shared state is unavailable or incompatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->